### PR TITLE
Add support for using a custom hosts file path.

### DIFF
--- a/API.md
+++ b/API.md
@@ -21,7 +21,14 @@ Represents a hosts file.
 ```go
 func NewHosts() (Hosts, error)
 ```
-Return a new instance of ``Hosts``.
+Return a new instance of ``Hosts`` using the default hosts file path.
+
+#### func  NewCustomHosts
+
+```go
+func NewCustomHosts(string customFilePath) (Hosts, error)
+```
+Return a new instance of ``Hosts`` using a custom hosts file path.
 
 #### func (*Hosts) Add
 

--- a/API.md
+++ b/API.md
@@ -26,7 +26,7 @@ Return a new instance of ``Hosts`` using the default hosts file path.
 #### func  NewCustomHosts
 
 ```go
-func NewCustomHosts(string customFilePath) (Hosts, error)
+func NewCustomHosts(customFilePath string) (Hosts, error)
 ```
 Return a new instance of ``Hosts`` using a custom hosts file path.
 

--- a/goodhosts.go
+++ b/goodhosts.go
@@ -222,7 +222,7 @@ func NewHosts() (Hosts, error) {
 }
 
 // Return a new instance of ``Hosts`` using a custom hosts file path.
-func NewCustomHosts(string customFilePath) (Hosts, error) {
+func NewCustomHosts(customFilePath string) (Hosts, error) {
 	osHostsFilePath := os.ExpandEnv(filepath.FromSlash(customFilePath))
 
 	hosts := Hosts{Path: osHostsFilePath}

--- a/goodhosts.go
+++ b/goodhosts.go
@@ -216,9 +216,14 @@ func (h Hosts) getIpPosition(ip string) int {
 	return -1
 }
 
-// Return a new instance of ``Hosts``.
+// Return a new instance of ``Hosts`` using the default hosts file path.
 func NewHosts() (Hosts, error) {
-	osHostsFilePath := os.ExpandEnv(filepath.FromSlash(hostsFilePath))
+	return NewCustomHosts(hostsFilePath)
+}
+
+// Return a new instance of ``Hosts`` using a custom hosts file path.
+func NewCustomHosts(string customFilePath) (Hosts, error) {
+	osHostsFilePath := os.ExpandEnv(filepath.FromSlash(customFilePath))
 
 	hosts := Hosts{Path: osHostsFilePath}
 


### PR DESCRIPTION
This adds support for being able to manage a hosts file in a non-default path, especially useful when leveraging a service like dnsmasq to include a hosts file that is exclusive to the system's default /etc/hosts:
```shell
# cat /etc/NetworkManager/dnsmasq.d/cluster.conf 
listen-address=::1
cache-size=1000
no-negcache
server=/cluster.local/10.254.0.10#53
domain-needed
expand-hosts
bogus-priv
addn-hosts=/run/cluster/hosts
```

The above use-case is for configuring a kubernetes cluster that ties in hostname resolution for dynamically "auto-discovered" hosts written to `/run/cluster/hosts` in addition to those statically defined in `/etc/hosts`.

Thanks!