### PR TITLE
add support for custom hosts location via an environment variable

### DIFF
--- a/goodhosts.go
+++ b/goodhosts.go
@@ -218,7 +218,13 @@ func (h Hosts) getIpPosition(ip string) int {
 
 // Return a new instance of ``Hosts``.
 func NewHosts() (Hosts, error) {
-	osHostsFilePath := os.ExpandEnv(filepath.FromSlash(hostsFilePath))
+	osHostsFilePath := ""
+
+	if os.Getenv("HOSTS_PATH") == "" {
+		osHostsFilePath = os.ExpandEnv(filepath.FromSlash(hostsFilePath))
+	} else {
+		osHostsFilePath = os.Getenv("HOSTS_PATH")
+	}
 
 	hosts := Hosts{Path: osHostsFilePath}
 


### PR DESCRIPTION
This is a change that allows for custom hosts locations to be passed in via an environment variable HOSTS_PATH. 

By having that capability the library/tool will compile and run in custom chroot/jails. All tests etc remain the same.

