### PR TITLE
Disable "appendToLine" behaviour on Windows due to limit on hostnames per line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,71 @@
 .DS_Store
 goodhosts
+
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser

--- a/.idea/goodhosts.iml
+++ b/.idea/goodhosts.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptSettings">
+    <option name="languageLevel" value="ES6" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/goodhosts.iml" filepath="$PROJECT_DIR$/.idea/goodhosts.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/runConfigurations/go_test_goodhosts.xml
+++ b/.idea/runConfigurations/go_test_goodhosts.xml
@@ -1,0 +1,13 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="go test goodhosts" type="GoTestRunConfiguration" factoryName="Go Test" nameIsGenerated="true">
+    <module name="goodhosts" />
+    <working_directory value="$PROJECT_DIR$/" />
+    <go_parameters value="-i" />
+    <framework value="gotest" />
+    <kind value="DIRECTORY" />
+    <package value="github.com/micdah/goodhosts" />
+    <directory value="$PROJECT_DIR$/" />
+    <filePath value="$PROJECT_DIR$/" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/const.go
+++ b/const.go
@@ -4,3 +4,8 @@ package goodhosts
 
 const hostsFilePath = "/etc/hosts"
 const eol = "\n"
+
+/*
+Whether or not to append multiple hosts pointing to the same IP on the same line
+*/
+const appendToLine = true

--- a/const.go
+++ b/const.go
@@ -8,4 +8,4 @@ const eol = "\n"
 /*
 Whether or not to append multiple hosts pointing to the same IP on the same line
 */
-const appendToLine = true
+var appendToLine = true

--- a/const_windows.go
+++ b/const_windows.go
@@ -6,4 +6,4 @@ const eol = "\r\n"
 /*
 Whether or not to append multiple hosts pointing to the same IP on the same line
 */
-const appendToLine = false // On windows, there is a 9-alias limit per line, so we disable appending behavior
+var appendToLine = false // On windows, there is a 9-alias limit per line, so we disable appending behavior

--- a/const_windows.go
+++ b/const_windows.go
@@ -2,3 +2,8 @@ package goodhosts
 
 const hostsFilePath = "${SystemRoot}/System32/drivers/etc/hosts"
 const eol = "\r\n"
+
+/*
+Whether or not to append multiple hosts pointing to the same IP on the same line
+*/
+const appendToLine = false // On windows, there is a 9-alias limit per line, so we disable appending behavior

--- a/goodhosts_test.go
+++ b/goodhosts_test.go
@@ -11,7 +11,7 @@ func TestHostsLineIsComment(t *testing.T) {
 	line := NewHostsLine(comment)
 	result := line.IsComment()
 	if !result {
-		t.Error(fmt.Sprintf("'%s' should be a comment"), comment)
+		t.Error(fmt.Sprintf("'%s' should be a comment", comment))
 	}
 }
 

--- a/goodhosts_test.go
+++ b/goodhosts_test.go
@@ -55,8 +55,14 @@ func TestHostsAddWhenIpHasOtherHosts(t *testing.T) {
 
 	hosts.Add("10.0.0.7", "brada", "yadda")
 
-	expectedLines := []HostsLine{
-		NewHostsLine("127.0.0.1 yadda"), NewHostsLine("10.0.0.7 nada yadda brada")}
+	var expectedLines []HostsLine
+	if appendToLine {
+		expectedLines = []HostsLine{
+			NewHostsLine("127.0.0.1 yadda"), NewHostsLine("10.0.0.7 nada yadda brada")}
+	} else {
+		expectedLines = []HostsLine{
+			NewHostsLine("127.0.0.1 yadda"), NewHostsLine("10.0.0.7 nada yadda"), NewHostsLine("10.0.0.7 brada")}
+	}
 
 	if !reflect.DeepEqual(hosts.Lines, expectedLines) {
 		t.Error("Add entry failed to append entry.")
@@ -70,8 +76,14 @@ func TestHostsAddWhenIpDoesntExist(t *testing.T) {
 
 	hosts.Add("10.0.0.7", "brada", "yadda")
 
-	expectedLines := []HostsLine{
-		NewHostsLine("127.0.0.1 yadda"), NewHostsLine("10.0.0.7 brada yadda")}
+	var expectedLines []HostsLine
+	if appendToLine {
+		expectedLines = []HostsLine{
+			NewHostsLine("127.0.0.1 yadda"), NewHostsLine("10.0.0.7 brada yadda")}
+	} else {
+		expectedLines = []HostsLine{
+			NewHostsLine("127.0.0.1 yadda"), NewHostsLine("10.0.0.7 brada"), NewHostsLine("10.0.0.7 yadda")}
+	}
 
 	if !reflect.DeepEqual(hosts.Lines, expectedLines) {
 		t.Error("Add entry failed to append entry.")
@@ -116,5 +128,224 @@ func TestHostsRemoveMultipleEntries(t *testing.T) {
 	hosts.Remove("127.0.0.1", "yadda", "prada")
 	if hosts.Lines[0].Raw != "127.0.0.1 nadda" {
 		t.Error("Failed to remove multiple entries.")
+	}
+}
+
+func TestHostsLine_IsComment(t *testing.T) {
+	tests := []struct {
+		name string
+		l    HostsLine
+		want bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.l.IsComment(); got != tt.want {
+				t.Errorf("HostsLine.IsComment() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewHostsLine(t *testing.T) {
+	type args struct {
+		raw string
+	}
+	tests := []struct {
+		name string
+		args args
+		want HostsLine
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewHostsLine(tt.args.raw); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewHostsLine() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHosts_IsWritable(t *testing.T) {
+	tests := []struct {
+		name string
+		h    *Hosts
+		want bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.h.IsWritable(); got != tt.want {
+				t.Errorf("Hosts.IsWritable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHosts_Load(t *testing.T) {
+	tests := []struct {
+		name    string
+		h       *Hosts
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.h.Load(); (err != nil) != tt.wantErr {
+				t.Errorf("Hosts.Load() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHosts_Flush(t *testing.T) {
+	tests := []struct {
+		name    string
+		h       Hosts
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.h.Flush(); (err != nil) != tt.wantErr {
+				t.Errorf("Hosts.Flush() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHosts_Add(t *testing.T) {
+	type args struct {
+		ip    string
+		hosts []string
+	}
+	tests := []struct {
+		name    string
+		h       *Hosts
+		args    args
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.h.Add(tt.args.ip, tt.args.hosts...); (err != nil) != tt.wantErr {
+				t.Errorf("Hosts.Add() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHosts_Has(t *testing.T) {
+	type args struct {
+		ip   string
+		host string
+	}
+	tests := []struct {
+		name string
+		h    Hosts
+		args args
+		want bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.h.Has(tt.args.ip, tt.args.host); got != tt.want {
+				t.Errorf("Hosts.Has() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHosts_Remove(t *testing.T) {
+	type args struct {
+		ip    string
+		hosts []string
+	}
+	tests := []struct {
+		name    string
+		h       *Hosts
+		args    args
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.h.Remove(tt.args.ip, tt.args.hosts...); (err != nil) != tt.wantErr {
+				t.Errorf("Hosts.Remove() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHosts_getHostPosition(t *testing.T) {
+	type args struct {
+		ip   string
+		host string
+	}
+	tests := []struct {
+		name string
+		h    Hosts
+		args args
+		want int
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.h.getHostPosition(tt.args.ip, tt.args.host); got != tt.want {
+				t.Errorf("Hosts.getHostPosition() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHosts_getIpPosition(t *testing.T) {
+	type args struct {
+		ip string
+	}
+	tests := []struct {
+		name string
+		h    Hosts
+		args args
+		want int
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.h.getIpPosition(tt.args.ip); got != tt.want {
+				t.Errorf("Hosts.getIpPosition() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewHosts(t *testing.T) {
+	tests := []struct {
+		name    string
+		want    Hosts
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewHosts()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewHosts() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewHosts() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/goodhosts_test.go
+++ b/goodhosts_test.go
@@ -7,128 +7,149 @@ import (
 )
 
 func TestHostsLineIsComment(t *testing.T) {
-	comment := "   # This is a comment   "
-	line := NewHostsLine(comment)
-	result := line.IsComment()
-	if !result {
-		t.Error(fmt.Sprintf("'%s' should be a comment", comment))
-	}
+	testWithAppendToLine(t, func(t *testing.T, appendToLine bool) {
+		comment := "   # This is a comment   "
+		line := NewHostsLine(comment)
+		result := line.IsComment()
+		if !result {
+			t.Error(fmt.Sprintf("'%s' should be a comment", comment))
+		}
+	})
 }
 
 func TestNewHostsLineWithEmptyLine(t *testing.T) {
-	line := NewHostsLine("")
-	if line.Raw != "" {
-		t.Error("Failed to load empty line.")
-	}
+	testWithAppendToLine(t, func(t *testing.T, appendToLine bool) {
+		line := NewHostsLine("")
+		if line.Raw != "" {
+			t.Error("Failed to load empty line.")
+		}
+	})
 }
 
 func TestHostsHas(t *testing.T) {
-	hosts := new(Hosts)
-	hosts.Lines = []HostsLine{
-		NewHostsLine("127.0.0.1 yadda"), NewHostsLine("10.0.0.7 nada")}
+	testWithAppendToLine(t, func(t *testing.T, appendToLine bool) {
+		hosts := new(Hosts)
+		hosts.Lines = []HostsLine{
+			NewHostsLine("127.0.0.1 yadda"), NewHostsLine("10.0.0.7 nada")}
 
-	// We should find this entry.
-	if !hosts.Has("10.0.0.7", "nada") {
-		t.Error("Couldn't find entry in hosts file.")
-	}
+		// We should find this entry.
+		if !hosts.Has("10.0.0.7", "nada") {
+			t.Error("Couldn't find entry in hosts file.")
+		}
 
-	// We shouldn't find this entry
-	if hosts.Has("10.0.0.7", "shuda") {
-		t.Error("Found entry that isn't in hosts file.")
-	}
+		// We shouldn't find this entry
+		if hosts.Has("10.0.0.7", "shuda") {
+			t.Error("Found entry that isn't in hosts file.")
+		}
+	})
 }
 
 func TestHostsHasDoesntFindMissingEntry(t *testing.T) {
-	hosts := new(Hosts)
-	hosts.Lines = []HostsLine{
-		NewHostsLine("127.0.0.1 yadda"), NewHostsLine("10.0.0.7 nada")}
+	testWithAppendToLine(t, func(t *testing.T, appendToLine bool) {
+		hosts := new(Hosts)
+		hosts.Lines = []HostsLine{
+			NewHostsLine("127.0.0.1 yadda"), NewHostsLine("10.0.0.7 nada")}
 
-	if hosts.Has("10.0.0.7", "brada") {
-		t.Error("Found missing entry.")
-	}
+		if hosts.Has("10.0.0.7", "brada") {
+			t.Error("Found missing entry.")
+		}
+	})
 }
 
 func TestHostsAddWhenIpHasOtherHosts(t *testing.T) {
-	hosts := new(Hosts)
-	hosts.Lines = []HostsLine{
-		NewHostsLine("127.0.0.1 yadda"), NewHostsLine("10.0.0.7 nada yadda")}
+	testWithAppendToLine(t, func(t *testing.T, appendToLine bool) {
+		hosts := new(Hosts)
+		hosts.Lines = []HostsLine{
+			NewHostsLine("127.0.0.1 yadda"), NewHostsLine("10.0.0.7 nada yadda")}
 
-	hosts.Add("10.0.0.7", "brada", "yadda")
+		_ = hosts.Add("10.0.0.7", "brada", "yadda")
 
-	var expectedLines []HostsLine
-	if appendToLine {
-		expectedLines = []HostsLine{
-			NewHostsLine("127.0.0.1 yadda"), NewHostsLine("10.0.0.7 nada yadda brada")}
-	} else {
-		expectedLines = []HostsLine{
-			NewHostsLine("127.0.0.1 yadda"), NewHostsLine("10.0.0.7 nada yadda"), NewHostsLine("10.0.0.7 brada")}
-	}
+		var expectedLines []HostsLine
+		if appendToLine {
+			expectedLines = []HostsLine{
+				NewHostsLine("127.0.0.1 yadda"),
+				NewHostsLine("10.0.0.7 nada yadda brada")}
+		} else {
+			expectedLines = []HostsLine{
+				NewHostsLine("127.0.0.1 yadda"),
+				NewHostsLine("10.0.0.7 nada yadda"),
+				NewHostsLine("10.0.0.7 brada")}
+		}
 
-	if !reflect.DeepEqual(hosts.Lines, expectedLines) {
-		t.Error("Add entry failed to append entry.")
-	}
+		if !reflect.DeepEqual(hosts.Lines, expectedLines) {
+			t.Error("Add entry failed to append entry.")
+		}
+	})
 }
 
 func TestHostsAddWhenIpDoesntExist(t *testing.T) {
-	hosts := new(Hosts)
-	hosts.Lines = []HostsLine{
-		NewHostsLine("127.0.0.1 yadda")}
+	testWithAppendToLine(t, func(t *testing.T, appendToLine bool) {
+		hosts := new(Hosts)
+		hosts.Lines = []HostsLine{
+			NewHostsLine("127.0.0.1 yadda")}
 
-	hosts.Add("10.0.0.7", "brada", "yadda")
+		_ = hosts.Add("10.0.0.7", "brada", "yadda")
 
-	var expectedLines []HostsLine
-	if appendToLine {
-		expectedLines = []HostsLine{
-			NewHostsLine("127.0.0.1 yadda"), NewHostsLine("10.0.0.7 brada yadda")}
-	} else {
-		expectedLines = []HostsLine{
-			NewHostsLine("127.0.0.1 yadda"), NewHostsLine("10.0.0.7 brada"), NewHostsLine("10.0.0.7 yadda")}
-	}
+		var expectedLines []HostsLine
+		if appendToLine {
+			expectedLines = []HostsLine{
+				NewHostsLine("127.0.0.1 yadda"), NewHostsLine("10.0.0.7 brada yadda")}
+		} else {
+			expectedLines = []HostsLine{
+				NewHostsLine("127.0.0.1 yadda"), NewHostsLine("10.0.0.7 brada"), NewHostsLine("10.0.0.7 yadda")}
+		}
 
-	if !reflect.DeepEqual(hosts.Lines, expectedLines) {
-		t.Error("Add entry failed to append entry.")
-	}
+		if !reflect.DeepEqual(hosts.Lines, expectedLines) {
+			t.Error("Add entry failed to append entry.")
+		}
+	})
 }
 
 func TestHostsRemoveWhenLastHostIpCombo(t *testing.T) {
-	hosts := new(Hosts)
-	hosts.Lines = []HostsLine{
-		NewHostsLine("127.0.0.1 yadda"), NewHostsLine("10.0.0.7 nada")}
+	testWithAppendToLine(t, func(t *testing.T, appendToLine bool) {
+		hosts := new(Hosts)
+		hosts.Lines = []HostsLine{
+			NewHostsLine("127.0.0.1 yadda"), NewHostsLine("10.0.0.7 nada")}
 
-	hosts.Remove("10.0.0.7", "nada")
+		_ = hosts.Remove("10.0.0.7", "nada")
 
-	expectedLines := []HostsLine{NewHostsLine("127.0.0.1 yadda")}
+		expectedLines := []HostsLine{NewHostsLine("127.0.0.1 yadda")}
 
-	if !reflect.DeepEqual(hosts.Lines, expectedLines) {
-		t.Error("Remove entry failed to remove entry.")
-	}
+		if !reflect.DeepEqual(hosts.Lines, expectedLines) {
+			t.Error("Remove entry failed to remove entry.")
+		}
+	})
 }
 
 func TestHostsRemoveWhenIpHasOtherHosts(t *testing.T) {
-	hosts := new(Hosts)
+	testWithAppendToLine(t, func(t *testing.T, appendToLine bool) {
+		hosts := new(Hosts)
 
-	hosts.Lines = []HostsLine{
-		NewHostsLine("127.0.0.1 yadda"), NewHostsLine("10.0.0.7 nada brada")}
+		hosts.Lines = []HostsLine{
+			NewHostsLine("127.0.0.1 yadda"), NewHostsLine("10.0.0.7 nada brada")}
 
-	hosts.Remove("10.0.0.7", "nada")
+		_ = hosts.Remove("10.0.0.7", "nada")
 
-	expectedLines := []HostsLine{
-		NewHostsLine("127.0.0.1 yadda"), NewHostsLine("10.0.0.7 brada")}
+		expectedLines := []HostsLine{
+			NewHostsLine("127.0.0.1 yadda"), NewHostsLine("10.0.0.7 brada")}
 
-	if !reflect.DeepEqual(hosts.Lines, expectedLines) {
-		t.Error("Remove entry failed to remove entry.")
-	}
+		if !reflect.DeepEqual(hosts.Lines, expectedLines) {
+			t.Error("Remove entry failed to remove entry.")
+		}
+	})
 }
 
 func TestHostsRemoveMultipleEntries(t *testing.T) {
-	hosts := new(Hosts)
-	hosts.Lines = []HostsLine{
-		NewHostsLine("127.0.0.1 yadda nadda prada")}
+	testWithAppendToLine(t, func(t *testing.T, appendToLine bool) {
+		hosts := new(Hosts)
+		hosts.Lines = []HostsLine{
+			NewHostsLine("127.0.0.1 yadda nadda prada")}
 
-	hosts.Remove("127.0.0.1", "yadda", "prada")
-	if hosts.Lines[0].Raw != "127.0.0.1 nadda" {
-		t.Error("Failed to remove multiple entries.")
-	}
+		_ = hosts.Remove("127.0.0.1", "yadda", "prada")
+		if hosts.Lines[0].Raw != "127.0.0.1 nadda" {
+			t.Error("Failed to remove multiple entries.")
+		}
+	})
 }
 
 func TestHostsLine_IsComment(t *testing.T) {
@@ -346,6 +367,17 @@ func TestNewHosts(t *testing.T) {
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NewHosts() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func testWithAppendToLine(t *testing.T, testFunc func(t *testing.T, appendToLine bool)) {
+	for _, testCase := range []struct {
+		appendToLine bool
+	}{{true}, {false}} {
+		t.Run(fmt.Sprintf("appendToLine=%v", testCase.appendToLine), func(t *testing.T) {
+			appendToLine = testCase.appendToLine
+			testFunc(t, testCase.appendToLine)
 		})
 	}
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -10,12 +10,12 @@ func TestItemInSlice(t *testing.T) {
 	list := []string{"hello", "brah"}
 	result := itemInSlice("goodbye", list)
 	if result {
-		t.Error(fmt.Sprintf("'%' should not have been found in slice.", item))
+		t.Error(fmt.Sprintf("'%s' should not have been found in slice.", item))
 	}
 
 	item = "hello"
 	result = itemInSlice(item, list)
 	if !result {
-		t.Error(fmt.Sprintf("'%' should have been found in slice.", item))
+		t.Error(fmt.Sprintf("'%s' should have been found in slice.", item))
 	}
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -19,3 +19,45 @@ func TestItemInSlice(t *testing.T) {
 		t.Error(fmt.Sprintf("'%s' should have been found in slice.", item))
 	}
 }
+
+func Test_itemInSlice(t *testing.T) {
+	type args struct {
+		item string
+		list []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := itemInSlice(tt.args.item, tt.args.list); got != tt.want {
+				t.Errorf("itemInSlice() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_buildRawLine(t *testing.T) {
+	type args struct {
+		ip    string
+		hosts []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildRawLine(tt.args.ip, tt.args.hosts); got != tt.want {
+				t.Errorf("buildRawLine() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
On Windows there is a limitation on the number of hostnames per line (_hostnames over this limit are simply ignored_), but there is no such limit as long as you add each mapping on an individual line.

This pull request introduces `appendToLine` constant, which is set based on OS targeted - disabling the behaviour of appending to existing lines when compiled for Windows.

I have also updates the test cases to test in both scenarios (_which is the reason why the constant is declared as `var` so the test case can change it_).